### PR TITLE
Add links before heading paragraph mode

### DIFF
--- a/md2gemini/__init__.py
+++ b/md2gemini/__init__.py
@@ -139,9 +139,8 @@ def md2gemini(
     # Add in hard linebreaks
     gemtext = gemtext.replace(LINEBREAK, NEWLINE)
 
-    # Process footnotes if at-end was used
-    if links == "at-end":
-        gemtext += NEWLINE + renderer._render_footnotes() + NEWLINE
+    # Add remaining footnotes at and of file
+    gemtext += NEWLINE + renderer._render_footnotes() + NEWLINE
 
     # Remove double link delims, which are produced by multiple footnotes
     gemtext = gemtext.replace(LINK_DELIM + LINK_DELIM, LINK_DELIM)

--- a/md2gemini/renderers.py
+++ b/md2gemini/renderers.py
@@ -253,23 +253,22 @@ class GeminiRenderer(
             self.footnote_texts = []
             return ret
 
+        text += self._end_of_paragraph()
+
+        return PARAGRAPH_DELIM + text + PARAGRAPH_DELIM
+
+    def _end_of_paragraph(self):
         # Process footnotes if it should
         if self.links in ["paragraph", "copy"] and len(self.footnotes) > 0:
-            ret = (
-                PARAGRAPH_DELIM
-                + text
-                + PARAGRAPH_DELIM * 2
-                + self._render_footnotes()
-                + PARAGRAPH_DELIM
-            )
+            ret = PARAGRAPH_DELIM + self._render_footnotes() + PARAGRAPH_DELIM
             self.footnotes = []
             self.footnote_texts = []  # For self.links == "copy"
             return ret
 
-        return PARAGRAPH_DELIM + text + PARAGRAPH_DELIM
+        return ""
 
     def heading(self, text, level):
-        return "#" * level + " " + text + NEWLINE * 2
+        return self._end_of_paragraph() + "#" * level + " " + text + NEWLINE * 2
 
     def thematic_break(self):
         """80 column split using hyphens."""
@@ -365,6 +364,12 @@ class GeminiRenderer(
                     ret_items.append(self.indent * (level - 1) + "* " + item.strip())
 
         return NEWLINE.join(ret_items) + NEWLINE * 2
+
+    # def finalize(self, data):
+    #     return (
+    #         self._end_of_paragraph()
+    #         + super(GeminiRenderer, self).finalize(data)
+    #     )
 
     # Elements that rely on plugins:
 

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -1,0 +1,31 @@
+from .util import normalize
+from md2gemini import md2gemini
+
+
+def f(md, links):
+    return normalize(md2gemini(md, links=links))
+
+
+def test_paragraph_links():
+    md = """
+* [foo](foo.md)
+
+# headline
+
+* [bar](bar.md)
+    """
+
+    gem = """
+* foo[1]
+
+=> foo.md 1: foo.md
+
+# headline
+
+* bar[2]
+
+
+=> bar.md 2: bar.md
+""".strip()
+
+    assert f(md, links="paragraph") == gem


### PR DESCRIPTION
When the link mode is "paragraph", then intention is to get links at the
and of each reasonable section of the document. When sections don't end
in paragraphs, this did not behave in a useful manner. Solution: Always
add all accumulated links before printing the next heading and at the
end of the file.

Tests are still missing.

Closes https://github.com/makeworld-the-better-one/md2gemini/issues/10