### PR TITLE
fix: --write does not respect full filepath.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ It works directly in Python, or on the command line. The command line version ca
 
 ### Command line
 ```
-usage: md2gemini [-h] [--version] [-w] [-d DIR] [-a] [-f] [-j]
+usage: md2gemini [-h] [--version] [-w] [-a] [-f] [-j]
                  [--code-tag CODE_TAG] [--img-tag IMG_TAG]
                  [--table-tag TABLE_TAG] [-i INDENT] [-l LINKS] [-p] [-s]
                  [-b BASE_URL] [-m]
@@ -125,7 +125,6 @@ optional arguments:
   --version             show program's version number and exit
   -w, --write           Write output to a new file of the same name, but with
                         a .gmi extension.
-  -d DIR, --dir DIR     The directory to write files to, if --write is used.
   -a, --ascii-table     Use ASCII to create tables, not Unicode.
   -f, --frontmatter     Remove Jekyll and Zola style front matter before
                         converting.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ It works directly in Python, or on the command line. The command line version ca
 
 ### Command line
 ```
-usage: md2gemini [-h] [--version] [-w] [-a] [-f] [-j]
+usage: md2gemini [-h] [--version] [-w] [-d DIR] [-a] [-f] [-j]
                  [--code-tag CODE_TAG] [--img-tag IMG_TAG]
                  [--table-tag TABLE_TAG] [-i INDENT] [-l LINKS] [-p] [-s]
                  [-b BASE_URL] [-m]
@@ -125,6 +125,7 @@ optional arguments:
   --version             show program's version number and exit
   -w, --write           Write output to a new file of the same name, but with
                         a .gmi extension.
+  -d DIR, --dir DIR     The directory to write files to, if --write is used.
   -a, --ascii-table     Use ASCII to create tables, not Unicode.
   -f, --frontmatter     Remove Jekyll and Zola style front matter before
                         converting.

--- a/md2gemini/__init__.py
+++ b/md2gemini/__init__.py
@@ -216,8 +216,8 @@ def __convert_file(file, args):
                 table_tag=args.table_tag,
             )
         if args.write:
-            newfile = os.path.splitext(os.path.basename(file))[0] + ".gmi"
-            with open(os.path.join(args.dir, newfile), "w") as f:
+            newfile = os.path.splitext(file)[0] + ".gmi"
+            with open(newfile, "w") as f:
                 f.write(gem)
         else:
             print(gem)
@@ -238,9 +238,6 @@ def main():
         "--write",
         action="store_true",
         help="Write output to a new file of the same name, but with a .gmi extension.",
-    )
-    parser.add_argument(
-        "-d", "--dir", help="The directory to write files to, if --write is used."
     )
     parser.add_argument(
         "-a",
@@ -314,11 +311,6 @@ def main():
     args = parser.parse_args()
 
     # Validation of command line args
-    if args.write and args.dir is None:
-        args.dir = "."
-    if args.write and not os.path.isdir(args.dir):
-        print("Directory", args.dir, "cannot be found.", file=sys.stderr)
-        sys.exit(1)
     if args.indent == "tab":
         args.indent = "\t"
     elif not args.indent is None:

--- a/md2gemini/__init__.py
+++ b/md2gemini/__init__.py
@@ -139,8 +139,9 @@ def md2gemini(
     # Add in hard linebreaks
     gemtext = gemtext.replace(LINEBREAK, NEWLINE)
 
-    # Add remaining footnotes at and of file
-    gemtext += NEWLINE + renderer._render_footnotes() + NEWLINE
+    # Process footnotes if at-end was used
+    if links == "at-end":
+        gemtext += NEWLINE + renderer._render_footnotes() + NEWLINE
 
     # Remove double link delims, which are produced by multiple footnotes
     gemtext = gemtext.replace(LINK_DELIM + LINK_DELIM, LINK_DELIM)
@@ -239,6 +240,9 @@ def main():
         help="Write output to a new file of the same name, but with a .gmi extension.",
     )
     parser.add_argument(
+        "-d", "--dir", help="The directory to write files to, if --write is used."
+    )
+    parser.add_argument(
         "-a",
         "--ascii-table",
         action="store_true",
@@ -310,6 +314,11 @@ def main():
     args = parser.parse_args()
 
     # Validation of command line args
+    if args.write and args.dir is None:
+        args.dir = "."
+    if args.write and not os.path.isdir(args.dir):
+        print("Directory", args.dir, "cannot be found.", file=sys.stderr)
+        sys.exit(1)
     if args.indent == "tab":
         args.indent = "\t"
     elif not args.indent is None:


### PR DESCRIPTION
### --write truncates the filepath (ex: "~/src/a.md"-> "a.md).
This seems somehow unexpected. I would expect it to write to filepath that I passed as parameter.
Also this behavior differs from other tools such as pandoc that will honor the filepath.

Furthermore the -dir option seems redundant since one can already write to stdout (and use redirection to accomplish the same goal)

### Modifications:
- --write uses full paths
- Remove redundant --dir flag