### PR TITLE
Add tests for markdown link conversion.

### DIFF
--- a/tests/test_markdown_link.py
+++ b/tests/test_markdown_link.py
@@ -1,0 +1,18 @@
+from .util import normalize
+from md2gemini import md2gemini
+
+
+def f(md):
+    return normalize(md2gemini(md, md_links=True))
+
+
+def test_markdown_path():
+    md = "[test](foo.md)"
+    gem = "=> foo.gmi test"
+    assert f(md) == gem
+
+
+def test_markdown_path_anchor():
+    md = "[test](foo.md#bar)"
+    gem = "=> foo.gmi test"
+    assert f(md) == gem


### PR DESCRIPTION
Includes test for links with anchors, which were fixed in
9aa67021ee54e4fc7f221535a4e432dd6589ba14.