### PR TITLE
implement "images-only" option for links parameter

### DIFF
--- a/md2gemini/__init__.py
+++ b/md2gemini/__init__.py
@@ -59,8 +59,9 @@ def md2gemini(
 
     links: Set to 'off' to turn off links, 'paragraph' to have footnotes at the end of each
     paragraph, or 'at-end' to have footnotes at the end of the document. You can also set it
-    to 'copy' to put links that copy the inline link text after each paragraph. Not using this
-    flag, or having any other value will result in regular, newline links.
+    to 'copy' to put links that copy the inline link text after each paragraph. You can also
+    set it to 'images-only' which is the same as 'off' but image hyperlinks will be converted.
+    Not using this flag, or having any other value will result in regular, newline links.
 
     plain: Set to True to remove special markings from output that text/gemini doesn't support,
     like the asterisks for bold and italics, as well as inline HTML.
@@ -290,7 +291,7 @@ def main():
         "-l",
         "--links",
         type=str,
-        help="Set to 'off' to turn off links, 'paragraph' to have footnotes at the end of each paragraph, or 'at-end' to have footnotes at the end of the document. You can also set it to 'copy' to put links that copy the inline link text after each paragraph. Not using this flag, or having any other value will result in regular, newline links.",
+        help="Set to 'off' to turn off links, 'paragraph' to have footnotes at the end of each paragraph, or 'at-end' to have footnotes at the end of the document. You can also set it to 'copy' to put links that copy the inline link text after each paragraph. You can also set it to 'images-only' which is the same as 'off' but image hyperlinks will be converted. Not using this flag, or having any other value will result in regular, newline links",
     )
     parser.add_argument(
         "-p",

--- a/md2gemini/renderers.py
+++ b/md2gemini/renderers.py
@@ -145,7 +145,7 @@ class GeminiRenderer(
             if text is None:
                 return link
             return text
-        if self.links == "off":
+        if self.links == "off" or self.links == "images-only":
             # Don't link, just leave the text as it was written
             if text is None:
                 return link
@@ -177,6 +177,9 @@ class GeminiRenderer(
 
         if alt is None:
             alt = ""
+
+        if self.links == "images-only":
+            return self._gem_link(src, alt.strip() + self.img_tag)
 
         if self.links == "off":
             if alt == "":


### PR DESCRIPTION
This PR adds an `images-only` option to the `--links` parameter. `--links images-only` behaves just like `--links off` except it *does* convert image links into gemtext link lines.

I'm not a Python developer, but this seems to work. Definitely open to better ways to implement this.